### PR TITLE
[Theming] Fix syntax errors in JS code.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,17 +18,15 @@ layout: compress
         {{ content }}
       </main>
       {% include sidebar.html %}
-      <script>
-        const el = document.getElementById('theme-switcher') = () => {
+      <script type='text/javascript'>
+        const el = document.getElementById('theme-switcher');
 
         if (window.localStorage && localStorage['currentTheme']) {
-          var iconClasses = iconForTheme(localStorage['currentTheme'])
-          el.className = iconClasses
+          var iconClasses = iconForTheme(localStorage['currentTheme']);
+          el.className = iconClasses;
+        } else {
+          el.className = iconForTheme();
         }
-        else {
-          el.className = iconForTheme()
-        }
-      }
       </script>
     </y-push-state>
 


### PR DESCRIPTION
The code had a trailing `= () => {` at the end of a var declaration.
That caused the element #theme-switcher to never be found so it wasn't
updated on init, only upon manual clicks/taps.

The other issue is that whatever is minifying the html output is concatenating items in `<script>` as a single line. In JavaScript, this causes syntax errors as it expects code to have semicolons if done that way. See [here](http://mislav.net/2010/05/semicolons/) or a more [concise version here](https://www.codecademy.com/blog/78) for more info

![](https://media1.giphy.com/media/t21eOG4BQMPJK/giphy.gif)